### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,23 +24,13 @@ This Nuxt module makes working with [Lucide](https://lucide.dev/) icons a breeze
 
 ## Quick Setup
 
-1. Add `nuxt-lucide-icons` dependency to your project
+Install the module to your Nuxt application with one command:
 
 ```bash
-npx nuxi@latest module add lucide-icons
+npx nuxi module add lucide-icons
 ```
 
-2. Add `nuxt-lucide-icons` to the `modules` section of `nuxt.config.ts`
-
-```ts
-export default defineNuxtConfig({
-  modules: [
-    'nuxt-lucide-icons'
-  ]
-})
-```
-
-3. That's it! You can now use [all Lucide icons](https://lucide.dev/icons) in your Nuxt app ✨
+That's it! You can now use [all Lucide icons](https://lucide.dev/icons) in your Nuxt app ✨
   
 ```vue
 <template>

--- a/README.md
+++ b/README.md
@@ -27,14 +27,7 @@ This Nuxt module makes working with [Lucide](https://lucide.dev/) icons a breeze
 1. Add `nuxt-lucide-icons` dependency to your project
 
 ```bash
-# Using pnpm
-pnpm add -D nuxt-lucide-icons
-
-# Using yarn
-yarn add --dev nuxt-lucide-icons
-
-# Using npm
-npm install --save-dev nuxt-lucide-icons
+npx nuxi@latest module add lucide-icons
 ```
 
 2. Add `nuxt-lucide-icons` to the `modules` section of `nuxt.config.ts`


### PR DESCRIPTION

This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏
