### PR TITLE
chore: update and replace lucide-vue-next with @lucide/vue (v1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This Nuxt module makes working with [Lucide](https://lucide.dev/) icons a breeze
 
 - [✨ &nbsp;Release Notes](/CHANGELOG.md)
 - [🏀 &nbsp;Online playground](https://stackblitz.com/github/swisnl/nuxt-lucide-icons?file=playground%2Fapp.vue)
-- [📖 &nbsp;Documentation](https://lucide.dev/docs/lucide-vue-next)
+- [📖 &nbsp;Documentation](https://lucide.dev/guide/vue)
 - [🖌️ &nbsp;Available icons](https://lucide.dev/icons)
 
 ## Features
@@ -31,7 +31,7 @@ npx nuxi module add lucide-icons
 ```
 
 That's it! You can now use [all Lucide icons](https://lucide.dev/icons) in your Nuxt app ✨
-  
+
 ```vue
 <template>
   <div>
@@ -73,23 +73,23 @@ Please see [CHANGELOG](CHANGELOG.md) for more information on what has changed re
   ```bash
   # Install dependencies
   npm install
-  
+
   # Generate type stubs
   npm run dev:prepare
-  
+
   # Develop with the playground
   npm run dev
-  
+
   # Build the playground
   npm run dev:build
-  
+
   # Run ESLint
   npm run lint
-  
+
   # Run Vitest
   npm run test
   npm run test:watch
-  
+
   # Release new version
   npm run release
   ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "nuxt-lucide-icons",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nuxt-lucide-icons",
-      "version": "1.1.0",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
+        "@lucide/vue": "^1.0.0",
         "@nuxt/kit": "^4.1.0",
-        "lucide-vue-next": "^0.x",
         "pathe": "^1.1.0",
         "scule": "^1.0.0"
       },
@@ -1397,6 +1397,15 @@
       "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@lucide/vue": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@lucide/vue/-/vue-1.0.2.tgz",
+      "integrity": "sha512-zyzsMTN9L97fxe31huBiRlaR1PPXpDluql5kuooiwFMPGJqWFTBP7AKvwcfIx91zoE3NIYyc+x+mOyQ3vReyJg==",
+      "license": "ISC",
+      "peerDependencies": {
+        "vue": ">=3.0.1"
+      }
     },
     "node_modules/@mapbox/node-pre-gyp": {
       "version": "2.0.0",
@@ -8662,15 +8671,6 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
-      }
-    },
-    "node_modules/lucide-vue-next": {
-      "version": "0.544.0",
-      "resolved": "https://registry.npmjs.org/lucide-vue-next/-/lucide-vue-next-0.544.0.tgz",
-      "integrity": "sha512-mDp/AdGOPIDkpFHnFiTWgQgCST9aBXHVaiobZfOMIvv7nrOukzF/TP+7KoOwrngdWRaH9TMiepMBIX1vsgKJ3g==",
-      "license": "ISC",
-      "peerDependencies": {
-        "vue": ">=3.0.1"
       }
     },
     "node_modules/magic-regexp": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@nuxt/kit": "^4.1.0",
-    "lucide-vue-next": "^0.x",
+    "@lucide/vue": "^1.0.0",
     "pathe": "^1.1.0",
     "scule": "^1.0.0"
   },

--- a/playground/app.vue
+++ b/playground/app.vue
@@ -3,6 +3,6 @@
     <h1>Nuxt Lucide Icons module playground!</h1>
     <LucideArrowDownAz />
     <LucideRocket color="red" />
-    <LucideGithub :size="32" />
+    <LucideStar :size="32" />
   </div>
 </template>

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,7 +1,7 @@
 import { addComponent, createResolver, defineNuxtModule } from '@nuxt/kit'
 import { join } from 'pathe'
 import { kebabCase } from 'scule'
-import * as icons from 'lucide-vue-next'
+import * as icons from '@lucide/vue'
 
 export interface LucideModuleOptions {
   namePrefix: string
@@ -21,12 +21,12 @@ export default defineNuxtModule<LucideModuleOptions>({
   },
 
   async setup(options: LucideModuleOptions) {
-    // Resolve path to lucide-vue-next.
+    // Resolve path to @lucide/vue.
     // The dependency is resolved relative to the location of this file, so that package managers like pnpm
     // without shamefully hoisting, or yarn with Plug'n'play enabled, also work.
     const { resolvePath } = createResolver(import.meta.url)
-    const entrypoint = await resolvePath('lucide-vue-next') // node_modules/lucide-vue-next/dist/cjs/lucide-vue-next.js
-    const root = join(entrypoint, '../../..') // node_modules/lucide-vue-next
+    const entrypoint = await resolvePath('@lucide/vue') // node_modules/@lucide/vue/dist/cjs/lucide-vue.js
+    const root = join(entrypoint, '../../..') // node_modules/@lucide/vue
 
     // Some icons are registered multiple times, but with different casing (e.g. ArrowDownAz/ArrowDownAZ
     // and Axis3d/Axis3D) so we increase priority to avoid a warning from Nuxt.


### PR DESCRIPTION
Migrates from `lucide-vue-next` to `@lucide/vue` (v1). The package was renamed in v1, so I updated the imports. This is the [migration guide](https://lucide.dev/guide/vue/migration)